### PR TITLE
Добавил генерацию релиза

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*' # Будет запускаться при создании тега с префиксом v (например, v1.0.0)
+
+jobs:
+  build:
+    name: Build and Create Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Полная история коммитов для генерации release notes
+
+      - name: Get the version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Generate changelog
+        id: changelog
+        uses: metcalfc/changelog-generator@v4.1.0
+        with:
+          myToken: ${{ secrets.GITHUB_TOKEN }}
+          base-ref: 'v${{ steps.get_version.outputs.VERSION }}'
+          head-ref: 'main'
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Release ${{ steps.get_version.outputs.VERSION }}
+          body: |
+            # Release Notes для версии ${{ steps.get_version.outputs.VERSION }}
+            
+            ## Что нового
+            
+            ${{ steps.changelog.outputs.changelog }}
+          draft: false
+          prerelease: false
+          files: |
+            README.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the creation of releases when a new tag with a `v` prefix (e.g., `v1.0.0`) is pushed. The workflow includes steps for building, generating release notes, and publishing the release.

### New GitHub Actions Workflow for Release Automation:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R47): Added a workflow triggered by tags prefixed with `v`. The workflow includes steps to check out the code, extract the version from the tag, generate a changelog using `metcalfc/changelog-generator@v4.1.0`, and create a release using `softprops/action-gh-release@v1`.