### PR TITLE
Добавил докусентацию OpenAPI

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: fastrapier1/ravr-backend:BCK-8
+    image: fastrapier1/ravr-backend:BCK-11
     ports:
       - "8080:8080"
     depends_on:

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+        
+        <!-- SpringDoc OpenAPI (Swagger) -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.4.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/ru/itis/fpsbackend/config/SecurityConfig.java
+++ b/src/main/java/ru/itis/fpsbackend/config/SecurityConfig.java
@@ -32,7 +32,13 @@ public class SecurityConfig {
     private static final String[] PUBLIC_URLS = {
             "/api/auth/**",
             "/api/public/**",
-            "/actuator/**"
+            "/actuator/**",
+            // Swagger UI и OpenAPI URLs
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/swagger-ui.html",
+            "/webjars/**",
+            "/swagger-resources/**"
     };
 
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter, JwtAuthenticationEntryPoint unauthorizedHandler) {

--- a/src/main/java/ru/itis/fpsbackend/config/swagger/OpenApiConfig.java
+++ b/src/main/java/ru/itis/fpsbackend/config/swagger/OpenApiConfig.java
@@ -1,0 +1,69 @@
+package ru.itis.fpsbackend.config.swagger;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.security.SecuritySchemes;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "FPS Backend API",
+                version = "1.0",
+                description = "API для FPS приложения",
+                contact = @Contact(
+                        name = "FPS Team",
+                        email = "support@fpsapp.ru"
+                )
+        ),
+        security = {
+                @SecurityRequirement(name = "Bearer Authentication")
+        }
+)
+@SecuritySchemes({
+        @SecurityScheme(
+                name = "Bearer Authentication",
+                type = SecuritySchemeType.HTTP,
+                bearerFormat = "JWT",
+                scheme = "bearer"
+        )
+})
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .servers(List.of(
+                        new Server().url("/").description("Локальный сервер")
+                ));
+    }
+    
+    @Bean
+    public GroupedOpenApi publicApi() {
+        return GroupedOpenApi.builder()
+                .group("public")
+                .pathsToMatch("/api/public/**", "/api/auth/**")
+                .build();
+    }
+    
+    @Bean
+    public GroupedOpenApi privateApi() {
+        return GroupedOpenApi.builder()
+                .group("private")
+                .pathsToMatch("/api/**")
+                .pathsToExclude("/api/public/**", "/api/auth/**")
+                .build();
+    }
+}

--- a/src/main/java/ru/itis/fpsbackend/config/swagger/SpringDocConfig.java
+++ b/src/main/java/ru/itis/fpsbackend/config/swagger/SpringDocConfig.java
@@ -1,0 +1,61 @@
+package ru.itis.fpsbackend.config.swagger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.web.method.HandlerMethod;
+import io.swagger.v3.oas.models.Operation;
+
+/**
+ * Конфигурация для настройки сериализации объектов в OpenAPI документации
+ */
+@Configuration
+public class SpringDocConfig {
+
+    /**
+     * Кастомизатор OpenAPI для исключения проблемных схем или полей, 
+     * которые могут вызывать ошибки при генерации документации
+     */
+    @Bean
+    public OpenApiCustomizer openApiCustomizer() {
+        return openApi -> {
+            // Здесь можно настроить какие схемы нужно исключить или модифицировать
+            // Это поможет избежать ошибок с циклическими ссылками
+            
+            // Пример: если нужно удалить определенную схему
+            // openApi.getComponents().getSchemas().remove("ProblemSchemaName");
+            
+            // Для отладки можно добавить информацию о версии API
+            openApi.getInfo().setDescription(openApi.getInfo().getDescription() + 
+                    "\n\nAPI Version: 1.0.0" + 
+                    "\nБолее подробная документация доступна на отдельных вкладках по группам API.");
+        };
+    }
+
+    /**
+     * Кастомизатор операций для добавления дополнительной информации к методам контроллера
+     */
+    @Bean
+    public OperationCustomizer operationCustomizer() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+            // Здесь можно настроить документацию для отдельных операций
+            // Например, добавить заметки или пометки
+            return operation;
+        };
+    }
+
+    /**
+     * Настроенный ObjectMapper для OpenAPI
+     */
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        // Отключаем сериализацию для пустых значений, это может помочь с некоторыми проблемами
+        objectMapper.setSerializationInclusion(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL);
+        return objectMapper;
+    }
+}

--- a/src/main/java/ru/itis/fpsbackend/dto/JwtResponse.java
+++ b/src/main/java/ru/itis/fpsbackend/dto/JwtResponse.java
@@ -1,16 +1,29 @@
 package ru.itis.fpsbackend.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Schema(description = "Ответ с JWT токенами после успешной аутентификации")
 public class JwtResponse {
+    @Schema(description = "Токен доступа (access token)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
     private String accessToken;
+    
+    @Schema(description = "Токен обновления (refresh token)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
     private String refreshToken;
+    
+    @Schema(description = "Тип токена", example = "Bearer", defaultValue = "Bearer")
     private final String tokenType = "Bearer";
+    
+    @Schema(description = "ID пользователя", example = "1")
     private Long id;
+    
+    @Schema(description = "Имя пользователя", example = "user1")
     private String username;
+    
+    @Schema(description = "Email пользователя", example = "user@example.com")
     private String email;
 
     public JwtResponse(String accessToken, String refreshToken, Long id, String username, String email) {

--- a/src/main/java/ru/itis/fpsbackend/dto/LoginRequest.java
+++ b/src/main/java/ru/itis/fpsbackend/dto/LoginRequest.java
@@ -1,17 +1,21 @@
 package ru.itis.fpsbackend.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
 @Setter
 @Getter
+@Schema(description = "Запрос на аутентификацию пользователя")
 public class LoginRequest {
     // Геттеры и сеттеры
     @NotBlank(message = "Имя пользователя не может быть пустым")
+    @Schema(description = "Имя пользователя", example = "user1", required = true)
     private String username;
 
     @NotBlank(message = "Пароль не может быть пустым")
+    @Schema(description = "Пароль пользователя", example = "password123", required = true)
     private String password;
 
 }

--- a/src/main/java/ru/itis/fpsbackend/dto/TokenRefreshRequest.java
+++ b/src/main/java/ru/itis/fpsbackend/dto/TokenRefreshRequest.java
@@ -1,5 +1,6 @@
 package ru.itis.fpsbackend.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
@@ -8,7 +9,9 @@ import lombok.*;
 @Builder
 @Getter
 @Setter
+@Schema(description = "Запрос на обновление токена доступа")
 public class TokenRefreshRequest {
     @NotBlank(message = "Refresh token cannot be blank")
+    @Schema(description = "Refresh токен для обновления", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", required = true)
     private String refreshToken;
 }

--- a/src/main/java/ru/itis/fpsbackend/dto/UserRegisterRequest.java
+++ b/src/main/java/ru/itis/fpsbackend/dto/UserRegisterRequest.java
@@ -1,5 +1,6 @@
 package ru.itis.fpsbackend.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -10,16 +11,20 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Запрос на регистрацию нового пользователя")
 public class UserRegisterRequest {
     @NotBlank(message = "Имя пользователя не может быть пустым")
     @Size(min = 3, max = 50, message = "Имя пользователя должно содержать от 3 до 50 символов")
+    @Schema(description = "Имя пользователя", example = "newuser", required = true, minLength = 3, maxLength = 50)
     private String username;
 
     @NotBlank(message = "Email не может быть пустым")
     @Email(message = "Неверный формат email")
+    @Schema(description = "Email пользователя", example = "user@example.com", required = true)
     private String email;
 
     @NotBlank(message = "Пароль не может быть пустым")
     @Size(min = 6, message = "Пароль должен содержать минимум 6 символов")
+    @Schema(description = "Пароль пользователя", example = "securePassword123", required = true, minLength = 6)
     private String password;
 }

--- a/src/main/java/ru/itis/fpsbackend/dto/UserResponse.java
+++ b/src/main/java/ru/itis/fpsbackend/dto/UserResponse.java
@@ -1,5 +1,6 @@
 package ru.itis.fpsbackend.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import ru.itis.fpsbackend.model.User;
 
@@ -9,9 +10,15 @@ import ru.itis.fpsbackend.model.User;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Schema(description = "Ответ с информацией о пользователе")
 public class UserResponse {
+    @Schema(description = "ID пользователя", example = "1")
     private Long id;
+    
+    @Schema(description = "Имя пользователя", example = "user1")
     private String username;
+    
+    @Schema(description = "Email пользователя", example = "user@example.com")
     private String email;
 
     public static UserResponse fromUser(User user) {

--- a/src/main/java/ru/itis/fpsbackend/security/JwtAuthenticationFilter.java
+++ b/src/main/java/ru/itis/fpsbackend/security/JwtAuthenticationFilter.java
@@ -28,7 +28,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String[] PUBLIC_URLS = {
             "/api/auth/**",
             "/api/public/**",
-            "/actuator/**"
+            "/actuator/**",
+            // Swagger UI и OpenAPI URLs
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/swagger-ui.html",
+            "/webjars/**",
+            "/swagger-resources/**"
     };
     
     private final AntPathMatcher pathMatcher = new AntPathMatcher();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -37,3 +37,17 @@ jwt.refresh.expiration=86400000
 # Logging
 logging.level.org.springframework.security=DEBUG
 logging.level.ru.itis.fpsbackend.security=DEBUG
+
+# SpringDoc OpenAPI настройки
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.api-docs.path=/v3/api-docs
+springdoc.packages-to-scan=ru.itis.fpsbackend.controller
+springdoc.paths-to-match=/api/**
+springdoc.show-actuator=false
+# Отключаем проверку моделей во время запуска (может помочь с ошибкой 500)
+springdoc.model-and-view-allowed=false
+springdoc.writer-with-default-pretty-printer=true
+# Включаем дебаг-режим для springdoc
+logging.level.org.springdoc=DEBUG


### PR DESCRIPTION
This pull request introduces significant changes to integrate OpenAPI (Swagger) into the project, enhance API documentation, and update configurations for better developer and user experience. The most important changes include adding dependencies and configurations for OpenAPI, updating security settings to allow access to Swagger-related URLs, and annotating DTOs and controllers with OpenAPI metadata.

### OpenAPI Integration:
* Added the `springdoc-openapi-starter-webmvc-ui` dependency in `pom.xml` to enable Swagger UI and OpenAPI support.
* Created `OpenApiConfig` and `SpringDocConfig` classes to configure OpenAPI settings, including API grouping, server details, and customizations for serialization and operation metadata. [[1]](diffhunk://#diff-bca35c839e3aeb3f61001d8dd555e3d20dc100d88aff4b285af1968c559f9058R1-R69) [[2]](diffhunk://#diff-e0353561313085f20d0c03420797c610afd2b34374dff1754f63d1f62f624ce0R1-R61)

### Security Updates:
* Updated `PUBLIC_URLS` in `SecurityConfig` and `JwtAuthenticationFilter` to allow access to Swagger UI and OpenAPI-related endpoints (e.g., `/swagger-ui/**`, `/v3/api-docs/**`). [[1]](diffhunk://#diff-23e7f34dde5f49ad19af65df5d9ecb9ea3bf68ab259760a1481e6bc43028fdd8L35-R41) [[2]](diffhunk://#diff-757ed050078d80ca50485b7f86be9b5a63bd759ba1a133af8e9a533e7e08edffL31-R37)

### API Documentation Enhancements:
* Annotated API controllers (e.g., `AuthController`) with OpenAPI metadata, including `@Tag`, `@Operation`, and `@ApiResponses`, to provide detailed descriptions of endpoints. [[1]](diffhunk://#diff-62425335b87f161e9ad276239470d16438fe06e4552e14fe6697998db8c99419R3-R8) [[2]](diffhunk://#diff-62425335b87f161e9ad276239470d16438fe06e4552e14fe6697998db8c99419R23) [[3]](diffhunk://#diff-62425335b87f161e9ad276239470d16438fe06e4552e14fe6697998db8c99419R38-R49) [[4]](diffhunk://#diff-62425335b87f161e9ad276239470d16438fe06e4552e14fe6697998db8c99419L42-R108)
* Added `@Schema` annotations to DTOs (e.g., `JwtResponse`, `LoginRequest`, `UserRegisterRequest`) to describe their fields in the generated API documentation. [[1]](diffhunk://#diff-953c738a1c6bb221a229345aa8ab504648abc4973424880afa8b68b8b9b0ee2dR3-R26) [[2]](diffhunk://#diff-2e603d1a098a73a4e9f094b7d61a9333d1c92d209a42fe02a69d8f0dcd3d58f4R3-R18) [[3]](diffhunk://#diff-1dbea752e73700a9c5ea41c2c42aeb341566feeaeed62d8fd3fe103346e409cfR3) [[4]](diffhunk://#diff-0c57ff70082ae03c5ea6407112f1166fda32a3eb84eb003b93b8fed7a5f0fdacR3) [[5]](diffhunk://#diff-cbccf128841f348d4d78f4f9f717ab21ae6f967e606db1fc4c80f1f1f2cd5f1eR3)

### Configuration Updates:
* Updated `application.properties` to include SpringDoc-specific settings, such as enabling Swagger UI, setting API paths, and configuring debugging options.

### Backend Image Update:
* Updated the Docker image version in `compose.yaml` from `BCK-8` to `BCK-11`.