### PR TITLE
Fix container images

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: fastrapier1/ravr-backend:BCK-11
+    image: fastrapier1/ravr-backend:latest
     ports:
       - "8080:8080"
     depends_on:


### PR DESCRIPTION
This pull request updates the Docker Compose configuration to ensure the backend service always uses the latest image version.

* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL3-R3): Changed the `image` tag for the `app` service from a specific version (`BCK-11`) to `latest` to always fetch the most recent backend image.