### PR TITLE
Fix container image

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: fastrapier1/ravr-backend:latest
+    image: fastrapier1/ravr-backend:main
     ports:
       - "8080:8080"
     depends_on:


### PR DESCRIPTION
This pull request includes a minor update to the `compose.yaml` file to ensure the application uses the correct Docker image version.

* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL3-R3): Changed the Docker image for the `app` service from `fastrapier1/ravr-backend:latest` to `fastrapier1/ravr-backend:main` to specify a more stable and consistent image tag.